### PR TITLE
New name for yumrepo module in Ansible 2.1

### DIFF
--- a/tasks/Fedora-repo.yml
+++ b/tasks/Fedora-repo.yml
@@ -2,7 +2,7 @@
 # add repos for virtualbox
 
 - name: "virtualbox | add Fedora {{ ansible_distribution_version }} - {{ ansible_architecture }} - VirtualBox repository"
-  yumrepo:
+  yum_repository:
     name="virtualbox"
     description="Fedora {{ ansible_distribution_version }} - {{ ansible_architecture }} - VirtualBox"
     baseurl="http://download.virtualbox.org/virtualbox/rpm/fedora/{{ ansible_distribution_version }}/{{ ansible_architecture }}"


### PR DESCRIPTION
Ansible 2.1.0.0 landed in Fedora 23
and without this fix task fails
